### PR TITLE
Fix for major dependencies issues. Further cleanups highly advised.

### DIFF
--- a/motion_module_tutorial/CMakeLists.txt
+++ b/motion_module_tutorial/CMakeLists.txt
@@ -9,8 +9,6 @@ project(motion_module_tutorial)
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  dynamixel_sdk
-  robotis_device
   robotis_framework_common
 )
 
@@ -28,6 +26,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES motion_module_tutorial
+  CATKIN_DEPENDS roscpp robotis_framework_common
 )
 
 ################################################################################

--- a/motion_module_tutorial/package.xml
+++ b/motion_module_tutorial/package.xml
@@ -11,7 +11,7 @@
   <url type="website">http://wiki.ros.org/motion_module_tutorial</url>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>robotis_device</build_depend>
   <build_depend>robotis_framework_common</build_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 </package>

--- a/sensor_module_tutorial/CMakeLists.txt
+++ b/sensor_module_tutorial/CMakeLists.txt
@@ -9,8 +9,6 @@ project(sensor_module_tutorial)
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  dynamixel_sdk
-  robotis_device
   robotis_framework_common
 )
 
@@ -28,6 +26,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES sensor_module_tutorial
+  CATKIN_DEPENDS roscpp robotis_framework_common
 )
 
 ################################################################################

--- a/sensor_module_tutorial/package.xml
+++ b/sensor_module_tutorial/package.xml
@@ -11,7 +11,7 @@
   <url type="website">http://wiki.ros.org/sensor_module_tutorial</url>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>robotis_device</build_depend>
   <build_depend>robotis_framework_common</build_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 </package>

--- a/thormang3_action_module/CMakeLists.txt
+++ b/thormang3_action_module/CMakeLists.txt
@@ -10,8 +10,6 @@ project(thormang3_action_module)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
-  dynamixel_sdk
-  robotis_device
   robotis_controller_msgs
   robotis_framework_common
   thormang3_action_module_msgs
@@ -31,6 +29,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES thormang3_action_module
+  CATKIN_DEPENDS roscpp robotis_framework_common
 )
 
 ################################################################################

--- a/thormang3_action_module/package.xml
+++ b/thormang3_action_module/package.xml
@@ -15,10 +15,10 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>dynamixel_sdk</build_depend>
-  <build_depend>robotis_device</build_depend>
+  <build_depend>robotis_framework_common</build_depend>
   <build_depend>robotis_controller_msgs</build_depend>
   <build_depend>thormang3_action_module_msgs</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 </package>

--- a/thormang3_base_module/CMakeLists.txt
+++ b/thormang3_base_module/CMakeLists.txt
@@ -8,8 +8,6 @@ project(thormang3_base_module)
 # Packages
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
-  dynamixel_sdk
-  robotis_device
   robotis_math
   robotis_controller_msgs
   robotis_framework_common
@@ -36,6 +34,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES thormang3_base_module
+  CATKIN_DEPENDS roscpp std_msgs robotis_framework_common
 )
 
 ################################################################################

--- a/thormang3_base_module/package.xml
+++ b/thormang3_base_module/package.xml
@@ -10,16 +10,16 @@
   <url type="repository">https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC</url>
   <url type="website">http://wiki.ros.org/thormang3_base_module</url>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>robotis_device</build_depend>
   <build_depend>robotis_math</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>robotis_framework_common</build_depend>
   <build_depend>thormang3_kinematics_dynamics</build_depend>
-  <run_depend>robotis_device</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>cmake_modules</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 </package>

--- a/thormang3_feet_ft_module/CMakeLists.txt
+++ b/thormang3_feet_ft_module/CMakeLists.txt
@@ -9,12 +9,8 @@ project(thormang3_feet_ft_module)
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  geometry_msgs
   cmake_modules
-  message_generation
-  dynamixel_sdk
   robotis_math
-  robotis_device
   robotis_framework_common
   thormang3_kinematics_dynamics
   thormang3_feet_ft_module_msgs
@@ -37,6 +33,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES thormang3_feet_ft_module
+  CATKIN_DEPENDS roscpp geometry_msgs robotis_framework_common
 )
 
 ################################################################################

--- a/thormang3_feet_ft_module/package.xml
+++ b/thormang3_feet_ft_module/package.xml
@@ -14,12 +14,15 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>cmake_modules</build_depend>
-  <build_depend>robotis_device</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>robotis_math</build_depend>
   <build_depend>robotis_controller_msgs</build_depend>
+  <build_depend>robotis_framework_common</build_depend>
   <build_depend>thormang3_kinematics_dynamics</build_depend>
   <build_depend>thormang3_feet_ft_module_msgs</build_depend>
   <build_depend>ati_ft_sensor</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>cmake_modules</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 </package>

--- a/thormang3_head_control_module/CMakeLists.txt
+++ b/thormang3_head_control_module/CMakeLists.txt
@@ -8,8 +8,6 @@ project(thormang3_head_control_module)
 # Packages
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
-  dynamixel_sdk
-  robotis_device
   robotis_math
   robotis_controller_msgs
   robotis_framework_common
@@ -34,6 +32,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES thormang3_head_control_module
+  CATKIN_DEPENDS roscpp robotis_framework_common
 )
 
 ################################################################################

--- a/thormang3_head_control_module/package.xml
+++ b/thormang3_head_control_module/package.xml
@@ -18,8 +18,10 @@
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>robotis_framework_common</build_depend>
   <run_depend>robotis_device</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>cmake_modules</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 </package>

--- a/thormang3_manager/CMakeLists.txt
+++ b/thormang3_manager/CMakeLists.txt
@@ -9,11 +9,9 @@ project(thormang3_manager)
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  dynamixel_sdk
-  robotis_framework_common
-  robotis_device
   robotis_controller
   robotis_controller_msgs
+  robotis_framework_common
   robotis_math
   cmake_modules
   ati_ft_sensor
@@ -40,7 +38,9 @@ find_package(Eigen REQUIRED)
 ################################################################################
 # Catkin specific configuration
 ################################################################################
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS roscpp robotis_framework_common
+)
 
 ################################################################################
 # Build

--- a/thormang3_manager/package.xml
+++ b/thormang3_manager/package.xml
@@ -13,9 +13,7 @@
   <url type="website">http://wiki.ros.org/thormang3_manager</url>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>dynamixel_sdk</build_depend>
   <build_depend>robotis_framework_common</build_depend>
-  <build_depend>robotis_device</build_depend>
   <build_depend>robotis_controller</build_depend>
   <build_depend>robotis_controller_msgs</build_depend>
   <build_depend>cmake_modules</build_depend>
@@ -28,4 +26,5 @@
   <build_depend>thormang3_action_module</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>robotis_controller</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 </package>

--- a/thormang3_manipulation_module/CMakeLists.txt
+++ b/thormang3_manipulation_module/CMakeLists.txt
@@ -8,8 +8,6 @@ project(thormang3_manipulation_module)
 # Packages
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
-  dynamixel_sdk
-  robotis_device
   robotis_math
   robotis_controller_msgs
   robotis_framework_common
@@ -37,6 +35,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES thormang3_manipulation_module
+  CATKIN_DEPENDS roscpp robotis_framework_common
 )
 
 ################################################################################

--- a/thormang3_manipulation_module/package.xml
+++ b/thormang3_manipulation_module/package.xml
@@ -14,7 +14,6 @@
   <url type="repository">https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC</url>
   <url type="website">http://wiki.ros.org/thormang3_manipulation_module</url>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>robotis_device</build_depend>
   <build_depend>robotis_math</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -22,9 +21,10 @@
   <build_depend>thormang3_manipulation_module_msgs</build_depend>
   <build_depend>thormang3_kinematics_dynamics</build_depend>
   <build_depend>cmake_modules</build_depend>
-  <run_depend>robotis_device</run_depend>
+  <build_depend>robotis_framework_common</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>cmake_modules</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 </package>

--- a/thormang3_walking_module/CMakeLists.txt
+++ b/thormang3_walking_module/CMakeLists.txt
@@ -38,7 +38,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES thormang3_walking_module
-  CATKIN_DEPENDS roscpp robotis_framework_common robotis_math thormang3_walking_module_msgs
+  CATKIN_DEPENDS roscpp robotis_framework_common robotis_math thormang3_walking_module_msgs thormang3_kinematics_dynamics thormang3_balance_control
 )
 
 ################################################################################

--- a/thormang3_walking_module/CMakeLists.txt
+++ b/thormang3_walking_module/CMakeLists.txt
@@ -14,8 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   cmake_modules
   eigen_conversions
-  dynamixel_sdk
-  robotis_device
   robotis_controller_msgs
   robotis_framework_common
   robotis_math
@@ -40,6 +38,7 @@ find_package(Eigen REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES thormang3_walking_module
+  CATKIN_DEPENDS roscpp robotis_framework_common robotis_math thormang3_walking_module_msgs
 )
 
 ################################################################################

--- a/thormang3_walking_module/package.xml
+++ b/thormang3_walking_module/package.xml
@@ -34,4 +34,6 @@
   <run_depend>robotis_math</run_depend>
   <run_depend>robotis_framework_common</run_depend>
   <run_depend>thormang3_walking_module_msgs</run_depend>
+  <run_depend>thormang3_kinematics_dynamics</run_depend>
+  <run_depend>thormang3_balance_control</run_depend>
 </package>

--- a/thormang3_walking_module/package.xml
+++ b/thormang3_walking_module/package.xml
@@ -19,17 +19,19 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen_conversions</build_depend>
-  <build_depend>robotis_device</build_depend>
   <build_depend>robotis_math</build_depend>
   <build_depend>robotis_controller_msgs</build_depend>
+  <build_depend>robotis_framework_common</build_depend>
   <build_depend>thormang3_walking_module_msgs</build_depend>
   <build_depend>thormang3_kinematics_dynamics</build_depend>
   <build_depend>thormang3_balance_control</build_depend>
-  <run_depend>robotis_device</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>cmake_modules</run_depend>
   <run_depend>eigen_conversions</run_depend>
+  <run_depend>robotis_math</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
+  <run_depend>thormang3_walking_module_msgs</run_depend>
 </package>


### PR DESCRIPTION
The package dependency chain is not defined cleanly. This is just a patch for the major issues I have encountered. I suggest to check your dependency chain carefully.

Requires https://github.com/ROBOTIS-GIT/ROBOTIS-Framework/pull/26
