### PR TITLE
optimized cpu usage and spin loop callback

### DIFF
--- a/motion_module_tutorial/src/motion_module_tutorial/motion_module_tutorial.cpp
+++ b/motion_module_tutorial/src/motion_module_tutorial/motion_module_tutorial.cpp
@@ -76,11 +76,9 @@ void MotionModuleTutorial::queueThread()
   /* publisher */
   pub1_ = ros_node.advertise<std_msgs::Int16>("/tutorial_publish", 1, true);
 
-  while (ros_node.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(1000);
-  }
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
+  while(ros_node.ok())
+    callback_queue.callAvailable(duration);
 }
 
 void MotionModuleTutorial::topicCallback(const std_msgs::Int16::ConstPtr &msg)

--- a/sensor_module_tutorial/src/sensor_module_tutorial/sensor_module_tutorial.cpp
+++ b/sensor_module_tutorial/src/sensor_module_tutorial/sensor_module_tutorial.cpp
@@ -72,11 +72,9 @@ void SensorModuleTutorial::queueThread()
   /* publisher */
   pub1_ = ros_node.advertise<std_msgs::Int16>("/tutorial_publish", 1, true);
 
-  while (ros_node.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(1000);
-  }
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
+  while(ros_node.ok())
+    callback_queue.callAvailable(duration);
 }
 
 void SensorModuleTutorial::topicCallback(const std_msgs::Int16::ConstPtr &msg)

--- a/thormang3_action_module/src/action_module.cpp
+++ b/thormang3_action_module/src/action_module.cpp
@@ -140,11 +140,9 @@ void ActionModule::queueThread()
   /* ROS Service Callback Functions */
   ros::ServiceServer is_running_server = ros_node.advertiseService("/robotis/action/is_running", &ActionModule::isRunningServiceCallback, this);
 
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
   while(ros_node.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(100);
-  }
+    callback_queue.callAvailable(duration);
 }
 
 bool ActionModule::isRunningServiceCallback(thormang3_action_module_msgs::IsRunning::Request  &req,

--- a/thormang3_base_module/src/base_module.cpp
+++ b/thormang3_base_module/src/base_module.cpp
@@ -242,11 +242,9 @@ void BaseModule::queueThread()
   // for gui
   ros::Subscriber ini_pose_msg_sub = ros_node.subscribe("/robotis/base/ini_pose", 5, &BaseModule::initPoseMsgCallback, this);
 
-  while (ros_node.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(100);
-  }
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
+  while(ros_node.ok())
+    callback_queue.callAvailable(duration);
 }
 
 void BaseModule::initPoseMsgCallback(const std_msgs::String::ConstPtr& msg)

--- a/thormang3_feet_ft_module/src/feet_force_torque_sensor_module.cpp
+++ b/thormang3_feet_ft_module/src/feet_force_torque_sensor_module.cpp
@@ -333,11 +333,9 @@ void FeetForceTorqueSensor::queueThread()
   thormang3_foot_ft_status_pub_  = ros_node.advertise<robotis_controller_msgs::StatusMsg>("/robotis/status", 1);
   thormang3_foot_ft_both_ft_pub_ = ros_node.advertise<thormang3_feet_ft_module_msgs::BothWrench>("/robotis/feet_ft/both_ft_value", 1);
 
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
   while(ros_node.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(100);
-  }
+    callback_queue.callAvailable(duration);
 }
 
 void FeetForceTorqueSensor::process(std::map<std::string, robotis_framework::Dynamixel *> dxls, std::map<std::string, robotis_framework::Sensor *> sensors)

--- a/thormang3_head_control_module/src/head_control_module.cpp
+++ b/thormang3_head_control_module/src/head_control_module.cpp
@@ -100,11 +100,9 @@ void HeadControlModule::queueThread()
   ros::Subscriber get_3d_lidar_sub   = ros_node.subscribe("/robotis/head_control/move_lidar", 1, &HeadControlModule::get3DLidarCallback, this);
   ros::Subscriber set_head_joint_sub = ros_node.subscribe("/robotis/head_control/set_joint_states", 1, &HeadControlModule::setHeadJointCallback, this);
 
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
   while(ros_node.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(100);
-  }
+    callback_queue.callAvailable(duration);
 }
 
 void HeadControlModule::get3DLidarCallback(const std_msgs::String::ConstPtr &msg)

--- a/thormang3_manipulation_module/src/manipulation_module.cpp
+++ b/thormang3_manipulation_module/src/manipulation_module.cpp
@@ -192,11 +192,9 @@ void ManipulationModule::queueThread()
   ros::ServiceServer get_kinematics_pose_server = ros_node.advertiseService("/robotis/manipulation/get_kinematics_pose",
                                                                             &ManipulationModule::getKinematicsPoseCallback, this);
 
-  while (ros_node.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(100);
-  }
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
+  while(ros_node.ok())
+    callback_queue.callAvailable(duration);
 }
 
 void ManipulationModule::initPoseMsgCallback(const std_msgs::String::ConstPtr& msg)

--- a/thormang3_walking_module/src/walking_module.cpp
+++ b/thormang3_walking_module/src/walking_module.cpp
@@ -218,11 +218,9 @@ void    WalkingMotionModule::queueThread()
   /* sensor topic subscribe */
   ros::Subscriber imu_data_sub    = ros_node.subscribe("/robotis/sensor/imu/imu",    3, &WalkingMotionModule::imuDataOutputCallback,        this);
 
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
   while(ros_node.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(100);
-  }
+    callback_queue.callAvailable(duration);
 }
 
 void WalkingMotionModule::publishRobotPose(void)


### PR DESCRIPTION
This patch optimizes cpu usage. Message are **processed immediately** now which is desired especially for real-time tasks (like balance control) and data synchronization. Before messages have been hold back up to 100ms (sometimes even 1s).
