### PR TITLE
added gazebo argument for convenient launch for simulated environments

### DIFF
--- a/thormang3_manager/launch/thormang3_manager.launch
+++ b/thormang3_manager/launch/thormang3_manager.launch
@@ -2,9 +2,10 @@
 
 <launch>    
     <arg name="use_imu" default="true"/>
-    <arg name="use_lidar" default="true" />  
+    <arg name="use_lidar" default="true" />
+    <arg name="gazebo" default="false" />
     
-    <param name="gazebo"                   value="false"    type="bool"/>
+    <param name="gazebo"                   value="$(arg gazebo)"    type="bool"/>
     <param name="gazebo_robot_name"        value="thormang3"/>
     
     <param name="offset_file_path"         value="$(find thormang3_manager)/config/offset.yaml"/>


### PR DESCRIPTION
Added gazebo argument for convenient launch for simulated environments. After applying the patch you can launch the manager for simulation by appending `gazebo:=true.`
