### PR TITLE
ROS Control for THORMANG3

### DIFF
--- a/thormang3_imu_module/CMakeLists.txt
+++ b/thormang3_imu_module/CMakeLists.txt
@@ -1,0 +1,164 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(thormang3_imu_module)
+
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  cmake_modules
+  geometry_msgs
+  sensor_msgs
+  robotis_controller_msgs
+  robotis_framework_common
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES thormang3_imu_module
+  CATKIN_DEPENDS roscpp cmake_modules geometry_msgs sensor_msgs robotis_controller_msgs robotis_framework_common
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+set(HEADERS
+  include/${PROJECT_NAME}/imu_sensor_module.h
+)
+
+set(SOURCES
+  src/imu_sensor_module.cpp
+)
+
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+# Declare a C++ library
+add_library(thormang3_imu_module ${SOURCES} ${HEADERS})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_mason_libs.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/thormang3_imu_module/include/thormang3_imu_module/imu_sensor_module.h
+++ b/thormang3_imu_module/include/thormang3_imu_module/imu_sensor_module.h
@@ -65,11 +65,11 @@ private:
 
   void publishStatusMsg(unsigned int type, std::string msg);
 
-  int             control_cycle_msec_;
-  boost::thread   queue_thread_;
-  boost::mutex    imu_sensor_mutex_;
+  int control_cycle_msec_;
+  boost::thread queue_thread_;
+  boost::mutex imu_sensor_mutex_;
 
-  ros::Publisher  thormang3_imu_status_pub_;
+  ros::Publisher  imu_status_pub_;
 };
 }
 

--- a/thormang3_imu_module/include/thormang3_imu_module/imu_sensor_module.h
+++ b/thormang3_imu_module/include/thormang3_imu_module/imu_sensor_module.h
@@ -1,0 +1,77 @@
+//=================================================================================================
+// Copyright (c) 2016, Alexander Stumpf, TU Darmstadt
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the Simulation, Systems Optimization and Robotics
+//       group, TU Darmstadt nor the names of its contributors may be used to
+//       endorse or promote products derived from this software without
+//       specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//=================================================================================================
+
+#ifndef THORMANG3_IMU_SENSOR_MODULE_H_
+#define THORMANG3_IMU_SENSOR_MODULE_H_
+
+#include <ros/ros.h>
+#include <ros/callback_queue.h>
+
+#include <boost/thread.hpp>
+
+#include <sensor_msgs/Imu.h>
+
+#include <robotis_framework_common/sensor_module.h>
+
+
+
+namespace thormang3
+{
+class ImuSensor : public robotis_framework::SensorModule, public robotis_framework::Singleton<ImuSensor>
+{
+public:
+  ImuSensor();
+  ~ImuSensor();
+
+  /* ROS Topic Callback Functions */
+  void imuSensorCallback(const sensor_msgs::Imu::ConstPtr msg, const std::string& tag);
+
+  void initialize(const int control_cycle_msec, robotis_framework::Robot* robot) override;
+  void process(std::map<std::string, robotis_framework::Dynamixel* > dxls, std::map<std::string, robotis_framework::Sensor*> sensors) override;
+
+  void stop();
+  bool isRunning();
+
+  bool gazebo_mode_;
+  std::string gazebo_robot_name_;
+
+private:
+  void msgQueueThread();
+
+  void publishStatusMsg(unsigned int type, std::string msg);
+
+  int             control_cycle_msec_;
+  boost::thread   queue_thread_;
+  boost::mutex    imu_sensor_mutex_;
+
+  ros::Publisher  thormang3_imu_status_pub_;
+};
+}
+
+
+#endif /* THORMANG3_FEET_FORCE_TORQUE_SENSOR_MODULE_H_ */

--- a/thormang3_imu_module/package.xml
+++ b/thormang3_imu_module/package.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<package>
+  <name>thormang3_imu_module</name>
+  <version>0.0.0</version>
+  <description>The thormang3_imu_module package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="stumpf@sim.tu-darmstadt.de">Alexander Stumpf</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>BSD</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/thormang3_foot_ft_module</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>robotis_controller_msgs</build_depend>
+  <build_depend>robotis_framework_common</build_depend>
+
+  <run_depend>roscpp</run_depend>
+  <run_depend>cmake_modules</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>robotis_controller_msgs</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/thormang3_imu_module/src/imu_sensor_module.cpp
+++ b/thormang3_imu_module/src/imu_sensor_module.cpp
@@ -111,11 +111,9 @@ void ImuSensor::msgQueueThread()
   /* publisher */
   thormang3_imu_status_pub_	= _ros_node.advertise<robotis_controller_msgs::StatusMsg>("robotis/status", 1);
 
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
   while(_ros_node.ok())
-  {
-    _callback_queue.callAvailable();
-    usleep(100);
-  }
+    _callback_queue.callAvailable(duration);
 }
 
 void ImuSensor::process(std::map<std::string, robotis_framework::Dynamixel*> /*dxls*/, std::map<std::string, robotis_framework::Sensor*> /*sensors*/)

--- a/thormang3_imu_module/src/imu_sensor_module.cpp
+++ b/thormang3_imu_module/src/imu_sensor_module.cpp
@@ -1,0 +1,124 @@
+#include <thormang3_imu_module/imu_sensor_module.h>
+
+#include <tf/tf.h>
+#include <robotis_controller_msgs/StatusMsg.h>
+
+
+
+using namespace thormang3;
+
+ImuSensor::ImuSensor()
+  : control_cycle_msec_(8)
+  , gazebo_robot_name_("robotis")
+  , gazebo_mode_(false)
+{
+  module_name_ = "thormang3_imu_sensor_module"; // set unique module name
+
+  result_["imu_orientation_q_x_raw"] = 0.0;
+  result_["imu_orientation_q_y_raw"] = 0.0;
+  result_["imu_orientation_q_z_raw"] = 0.0;
+  result_["imu_orientation_q_w_raw"] = 1.0;
+
+  result_["imu_orientation_r_raw"] = 0.0;
+  result_["imu_orientation_p_raw"] = 0.0;
+  result_["imu_orientation_y_raw"] = 0.0;
+
+  result_["imu_linear_acceleration_x_raw"] = 0.0;
+  result_["imu_linear_acceleration_y_raw"] = 0.0;
+  result_["imu_linear_acceleration_z_raw"] = 0.0;
+
+  result_["imu_angular_velocity_x_raw"] = 0.0;
+  result_["imu_angular_velocity_y_raw"] = 0.0;
+  result_["imu_angular_velocity_z_raw"] = 0.0;
+
+  result_["imu_orientation_q_x_filtered"] = 0.0;
+  result_["imu_orientation_q_y_filtered"] = 0.0;
+  result_["imu_orientation_q_z_filtered"] = 0.0;
+  result_["imu_orientation_q_w_filtered"] = 1.0;
+
+  result_["imu_orientation_r_filtered"] = 0.0;
+  result_["imu_orientation_p_filtered"] = 0.0;
+  result_["imu_orientation_y_filtered"] = 0.0;
+
+  result_["imu_linear_acceleration_x_filtered"] = 0.0;
+  result_["imu_linear_acceleration_y_filtered"] = 0.0;
+  result_["imu_linear_acceleration_z_filtered"] = 0.0;
+
+  result_["imu_angular_velocity_x_filtered"] = 0.0;
+  result_["imu_angular_velocity_y_filtered"] = 0.0;
+  result_["imu_angular_velocity_z_filtered"] = 0.0;
+}
+
+ImuSensor::~ImuSensor()
+{
+  queue_thread_.join();
+}
+
+void ImuSensor::initialize(const int control_cycle_msec, robotis_framework::Robot* robot)
+{
+  control_cycle_msec_ = control_cycle_msec;
+
+  queue_thread_       = boost::thread(boost::bind(&ImuSensor::msgQueueThread, this));
+}
+
+void ImuSensor::publishStatusMsg(unsigned int type, std::string msg)
+{
+  robotis_controller_msgs::StatusMsg _status;
+  _status.header.stamp = ros::Time::now();
+  _status.type = type;
+  _status.module_name = "IMU";
+  _status.status_msg = msg;
+
+  thormang3_imu_status_pub_.publish(_status);
+}
+
+void ImuSensor::imuSensorCallback(const sensor_msgs::Imu::ConstPtr msg, const std::string& tag)
+{
+  boost::mutex::scoped_lock lock(imu_sensor_mutex_);
+
+  result_["imu_orientation_q_x_" + tag] = msg->orientation.x;
+  result_["imu_orientation_q_y_" + tag] = msg->orientation.y;
+  result_["imu_orientation_q_z_" + tag] = msg->orientation.z;
+  result_["imu_orientation_q_w_" + tag] = msg->orientation.w;
+
+  tf::Quaternion q;
+  tf::quaternionMsgToTF(msg->orientation, q);
+  tf::Matrix3x3(q).getRPY(result_["imu_orientation_r_" + tag], result_["imu_orientation_p_" + tag], result_["imu_orientation_y_" + tag]);
+
+  result_["imu_linear_acceleration_x_" + tag] = msg->linear_acceleration.x;
+  result_["imu_linear_acceleration_y_" + tag] = msg->linear_acceleration.y;
+  result_["imu_linear_acceleration_z_" + tag] = msg->linear_acceleration.z;
+
+  result_["imu_angular_velocity_x_" + tag] = msg->angular_velocity.x;
+  result_["imu_angular_velocity_y_" + tag] = msg->angular_velocity.y;
+  result_["imu_angular_velocity_z_" + tag] = msg->angular_velocity.z;
+}
+
+void ImuSensor::msgQueueThread()
+{
+  ros::NodeHandle     _ros_node;
+  ros::CallbackQueue  _callback_queue;
+
+  _ros_node.setCallbackQueue(&_callback_queue);
+
+  /* subscriber */
+  //ros::Subscriber ft_calib_command_sub	= _ros_node.subscribe("robotis/wrist_ft/ft_calib_command",	1, &ThorMang3ImuSensor::FTSensorCalibrationCommandCallback, this);
+  ros::Subscriber imu_raw_sub = _ros_node.subscribe<sensor_msgs::Imu>(gazebo_mode_ ? "/gazebo/" + gazebo_robot_name_ + "/sensor/imu" : "sensor/imu/raw",	1,
+                                                    boost::bind(&ImuSensor::imuSensorCallback, this, _1, std::string("raw")));
+  ros::Subscriber imu_filtered_sub = _ros_node.subscribe<sensor_msgs::Imu>(gazebo_mode_ ? "/gazebo/" + gazebo_robot_name_ + "/sensor/imu" : "sensor/imu/filtered",	1,
+                                                    boost::bind(&ImuSensor::imuSensorCallback, this, _1, std::string("filtered")));
+
+  /* publisher */
+  thormang3_imu_status_pub_	= _ros_node.advertise<robotis_controller_msgs::StatusMsg>("robotis/status", 1);
+
+  while(_ros_node.ok())
+  {
+    _callback_queue.callAvailable();
+    usleep(100);
+  }
+}
+
+void ImuSensor::process(std::map<std::string, robotis_framework::Dynamixel*> /*dxls*/, std::map<std::string, robotis_framework::Sensor*> /*sensors*/)
+{
+  // nothing to do
+}

--- a/thormang3_manager/CMakeLists.txt
+++ b/thormang3_manager/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   ati_ft_sensor
   thormang3_kinematics_dynamics
+  thormang3_imu_module
   thormang3_feet_ft_module
   thormang3_balance_control
   thormang3_action_module

--- a/thormang3_manager/CMakeLists.txt
+++ b/thormang3_manager/CMakeLists.txt
@@ -4,6 +4,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(thormang3_manager)
 
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+
 ################################################################################
 # Packages
 ################################################################################
@@ -25,6 +27,7 @@ find_package(catkin REQUIRED COMPONENTS
   thormang3_manipulation_module
   thormang3_walking_module
   thormang3_base_module
+  thormang3_ros_control_module
 )
 
 find_package(Eigen REQUIRED)

--- a/thormang3_manager/launch/thormang3_manager.launch
+++ b/thormang3_manager/launch/thormang3_manager.launch
@@ -21,6 +21,9 @@
     
     <!-- lidar -->    
     <include file="$(find thormang3_description)/launch/thor_laserscan.launch" if="$(arg use_lidar)"/> 
+
+    <!-- ros control module -->
+    <include file="$(find thormang3_ros_control_module)/launch/load_trajectory_controllers.launch" />
     
     <!-- THORMANG3 Manager -->
     <node name="thormang3_manager" pkg="thormang3_manager" type="thormang3_manager" output="screen"/>

--- a/thormang3_manager/package.xml
+++ b/thormang3_manager/package.xml
@@ -26,6 +26,7 @@
   <build_depend>thormang3_walking_module</build_depend>
   <build_depend>thormang3_base_module</build_depend>
   <build_depend>thormang3_action_module</build_depend>
+  <build_depend>thormang3_ros_control_module</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>robotis_controller</run_depend>
 </package>

--- a/thormang3_manager/package.xml
+++ b/thormang3_manager/package.xml
@@ -19,6 +19,7 @@
   <build_depend>robotis_controller</build_depend>
   <build_depend>robotis_controller_msgs</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>thormang3_imu_module</build_depend>
   <build_depend>thormang3_feet_ft_module</build_depend>
   <build_depend>thormang3_balance_control</build_depend>
   <build_depend>thormang3_head_control_module</build_depend>

--- a/thormang3_manager/src/thormang3_manager.cpp
+++ b/thormang3_manager/src/thormang3_manager.cpp
@@ -46,6 +46,7 @@
 #include "thormang3_head_control_module/head_control_module.h"
 #include "thormang3_manipulation_module/manipulation_module.h"
 #include "thormang3_walking_module/walking_module.h"
+#include "thormang3_ros_control_module/ros_control_module.h"
 
 
 using namespace thormang3;
@@ -100,6 +101,7 @@ int main(int argc, char **argv)
     controller->addMotionModule((robotis_framework::MotionModule*)ManipulationModule::getInstance());
     controller->addMotionModule((robotis_framework::MotionModule*)HeadControlModule::getInstance());
     controller->addMotionModule((robotis_framework::MotionModule*)WalkingMotionModule::getInstance());
+    controller->addMotionModule((robotis_framework::MotionModule*)RosControlModule::getInstance());
 
     controller->startTimer();
 

--- a/thormang3_manager/src/thormang3_manager.cpp
+++ b/thormang3_manager/src/thormang3_manager.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
     }
 
     if(offset_file != "")
-        controller->loadOffsets(offset_file);
+        controller->loadOffset(offset_file);
 
     sleep(1);
 

--- a/thormang3_manager/src/thormang3_manager.cpp
+++ b/thormang3_manager/src/thormang3_manager.cpp
@@ -38,6 +38,7 @@
 #include "robotis_controller/robotis_controller.h"
 
 /* Sensor Module Header */
+#include "thormang3_imu_module/imu_sensor_module.h"
 #include "thormang3_feet_ft_module/feet_force_torque_sensor_module.h"
 
 /* Motion Module Header */
@@ -65,14 +66,16 @@ int main(int argc, char **argv)
 
     std::string init_file   = nh.param<std::string>("init_file_path", "");
 
+    std::string gazebo_robot_name = nh.param<std::string>("gazebo_robot_name", controller->gazebo_robot_name_);
+    controller->gazebo_robot_name_ = gazebo_robot_name;
+    ImuSensor::getInstance()->gazebo_robot_name_ = gazebo_robot_name;
+
     /* gazebo simulation */
-    controller->gazebo_mode_ = nh.param<bool>("gazebo", false);
-    if(controller->gazebo_mode_ == true)
+    if(nh.param<bool>("gazebo", false))
     {
+        controller->gazebo_mode_ = true;
+        ImuSensor::getInstance()->gazebo_mode_ = true;
         ROS_WARN("SET TO GAZEBO MODE!");
-        std::string robot_name = nh.param<std::string>("gazebo_robot_name", "");
-        if(robot_name != "")
-            controller->gazebo_robot_name_ = robot_name;
     }
 
     if(robot_file == "")
@@ -88,11 +91,12 @@ int main(int argc, char **argv)
     }
 
     if(offset_file != "")
-        controller->loadOffset(offset_file);
+        controller->loadOffsets(offset_file);
 
     sleep(1);
 
     /* Add Sensor Module */
+    controller->addSensorModule((robotis_framework::SensorModule*)ImuSensor::getInstance());
     controller->addSensorModule((robotis_framework::SensorModule*)FeetForceTorqueSensor::getInstance());
 
     /* Add Motion Module */

--- a/thormang3_ros_control_module/CMakeLists.txt
+++ b/thormang3_ros_control_module/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   hardware_interface
   controller_manager
-  robotis_device
+  robotis_framework_common
 )
 
 ## System dependencies are found with CMake's conventions
@@ -92,7 +92,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES thormang3_ros_control_module
-  CATKIN_DEPENDS roscpp rospy actionlib_msgs actionlib std_msgs hardware_interface controller_manager robotis_device 
+  CATKIN_DEPENDS roscpp rospy actionlib_msgs actionlib std_msgs hardware_interface controller_manager robotis_framework_common
 #  DEPENDS system_lib
 )
 

--- a/thormang3_ros_control_module/CMakeLists.txt
+++ b/thormang3_ros_control_module/CMakeLists.txt
@@ -106,11 +106,11 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 ## Specify additional locations of header files
 set(HEADERS
-    include/${PROJECT_NAME}/ros_control_module.h
+  include/${PROJECT_NAME}/ros_control_module.h
 )
 
 set(SOURCES
-    src/ros_control_module.cpp
+  src/ros_control_module.cpp
 )
 
 ## Declare a cpp library

--- a/thormang3_ros_control_module/CMakeLists.txt
+++ b/thormang3_ros_control_module/CMakeLists.txt
@@ -1,0 +1,173 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(thormang3_ros_control_module)
+
+#set(CMAKE_BUILD_TYPE Debug)
+#set(CMAKE_BUILD_TYPE Release)
+#set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rospy
+  actionlib_msgs
+  actionlib
+  std_msgs
+  hardware_interface
+  controller_manager
+  robotis_device
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES thormang3_ros_control_module
+  CATKIN_DEPENDS roscpp rospy actionlib_msgs actionlib std_msgs hardware_interface controller_manager robotis_device 
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+## Specify additional locations of header files
+set(HEADERS
+    include/${PROJECT_NAME}/ros_control_module.h
+)
+
+set(SOURCES
+    src/ros_control_module.cpp
+)
+
+## Declare a cpp library
+add_library(${PROJECT_NAME} ${SOURCES} ${HEADERS})
+set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS thormang3_ros_control_module thormang3_ros_control_module_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_thormang3_ros_control_module.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/thormang3_ros_control_module/README.md
+++ b/thormang3_ros_control_module/README.md
@@ -1,0 +1,2 @@
+# thor_mang_ros_control
+Provides custom ros_control controllers for thor_mang and ros_control setup for the (real) thor_mang robot.

--- a/thormang3_ros_control_module/config/ros_control_module_config.yaml
+++ b/thormang3_ros_control_module/config/ros_control_module_config.yaml
@@ -1,3 +1,4 @@
+# defines joints to be controlled by ros control module
 joints:
   ["head_p",
    "head_y",
@@ -16,3 +17,8 @@ joints:
    "r_arm_wr_r",
    "r_arm_wr_y",
    "r_arm_wr_p"]
+
+# defines which ft sensors to be interfaced
+ft_sensors:
+  l_foot: ["l_foot", "l_foot_ft_link"]
+  r_foot: ["r_foot", "r_foot_ft_link"]

--- a/thormang3_ros_control_module/config/ros_control_module_config.yaml
+++ b/thormang3_ros_control_module/config/ros_control_module_config.yaml
@@ -16,7 +16,19 @@ joints:
    "r_arm_el_y",
    "r_arm_wr_r",
    "r_arm_wr_y",
-   "r_arm_wr_p"]
+   "r_arm_wr_p",
+   "l_leg_hip_y",
+   "l_leg_hip_r",
+   "l_leg_hip_p",
+   "l_leg_kn_p",
+   "l_leg_an_r",
+   "l_leg_an_p",
+   "r_leg_hip_y",
+   "r_leg_hip_r",
+   "r_leg_hip_p",
+   "r_leg_kn_p",
+   "r_leg_an_r",
+   "r_leg_an_p"]
 
 # defines which ft sensors to be interfaced
 ft_sensors:

--- a/thormang3_ros_control_module/config/ros_control_module_config.yaml
+++ b/thormang3_ros_control_module/config/ros_control_module_config.yaml
@@ -1,0 +1,18 @@
+joints:
+  ["head_p",
+   "head_y",
+   "torso_y", 
+   "l_arm_sh_p1",
+   "l_arm_sh_r",
+   "l_arm_sh_p2",
+   "l_arm_el_y",
+   "l_arm_wr_r",
+   "l_arm_wr_y",
+   "l_arm_wr_p",
+   "r_arm_sh_p1",
+   "r_arm_sh_r",
+   "r_arm_sh_p2",
+   "r_arm_el_y",
+   "r_arm_wr_r",
+   "r_arm_wr_y",
+   "r_arm_wr_p"]

--- a/thormang3_ros_control_module/config/thor_mang_position_controllers.yaml
+++ b/thormang3_ros_control_module/config/thor_mang_position_controllers.yaml
@@ -1,0 +1,11 @@
+#thor:
+# position controllers ---------------------------------------
+  head_p_position_controller:
+    type: position_controllers/JointPositionController
+    joint: head_p
+    pid: {p: 10.0, i: 0.0, d: 0.0}
+
+  head_y_position_controller:
+    type: position_controllers/JointPositionController
+    joint: head_y
+    pid: {p: 10.0, i: 0.0, d: 0.0}

--- a/thormang3_ros_control_module/config/thor_mang_trajectory_controllers.yaml
+++ b/thormang3_ros_control_module/config/thor_mang_trajectory_controllers.yaml
@@ -1,0 +1,105 @@
+#thor:
+# trajectory controllers ---------------------------------------
+
+# -------------------- head controller -------------------
+ head_traj_controller:
+    type: "position_controllers/JointTrajectoryController"
+    joints:
+      - head_p
+      - head_y
+      
+    constraints:
+      goal_time: &goal_time_constraint 4.0
+      head_p:
+        goal: &goal_pos_constraint 0.5
+        trajectory: &trajectory_pos_constraint 1.0
+      head_y:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+
+# -------------------- torso controller -------------------
+ torso_traj_controller:
+    type: "position_controllers/JointTrajectoryController"
+    joints:
+      - torso_y
+      
+    constraints:
+      goal_time: *goal_time_constraint
+      stopped_velocity_tolerance: 1.0
+      torso_y:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+
+# -------------------- left arm controller -------------------
+ left_arm_traj_controller:
+    type: "position_controllers/JointTrajectoryController"
+    joints:
+      - l_arm_sh_p1
+      - l_arm_sh_r
+      - l_arm_sh_p2
+      - l_arm_el_y
+      - l_arm_wr_r
+      - l_arm_wr_y
+      - l_arm_wr_p
+      
+    constraints:
+      goal_time: *goal_time_constraint
+      stopped_velocity_tolerance: 1.0
+      l_arm_sh_p1:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      l_arm_sh_r:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint        
+      l_arm_sh_p2:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      l_arm_el_y:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint        
+      l_arm_wr_r:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      l_arm_wr_y:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      l_arm_wr_p:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+        
+# -------------------- right arm controller -------------------
+ right_arm_traj_controller:
+    type: "position_controllers/JointTrajectoryController"
+    joints:
+      - r_arm_sh_p1
+      - r_arm_sh_r
+      - r_arm_sh_p2
+      - r_arm_el_y
+      - r_arm_wr_r
+      - r_arm_wr_y
+      - r_arm_wr_p
+      
+    constraints:
+      goal_time: *goal_time_constraint
+      stopped_velocity_tolerance: 1.0
+      r_arm_sh_p1:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      r_arm_sh_r:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint        
+      r_arm_sh_p2:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      r_arm_el_y:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint        
+      r_arm_wr_r:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      r_arm_wr_y:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      r_arm_wr_p:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint

--- a/thormang3_ros_control_module/config/thor_mang_trajectory_controllers.yaml
+++ b/thormang3_ros_control_module/config/thor_mang_trajectory_controllers.yaml
@@ -103,3 +103,69 @@
       r_arm_wr_p:
         goal: *goal_pos_constraint
         trajectory: *trajectory_pos_constraint
+
+# -------------------- left leg controller -------------------
+ left_leg_traj_controller:
+    type: "position_controllers/JointTrajectoryController"
+    joints:
+      - l_leg_hip_y
+      - l_leg_hip_r
+      - l_leg_hip_p
+      - l_leg_kn_p
+      - l_leg_an_r
+      - l_leg_an_p
+      
+    constraints:
+      goal_time: *goal_time_constraint
+      stopped_velocity_tolerance: 1.0
+      l_leg_hip_y:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      l_leg_hip_r:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint        
+      l_leg_hip_p:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      l_leg_kn_p:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint        
+      l_leg_an_r:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      l_leg_an_p:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+        
+# -------------------- right leg controller -------------------
+ right_leg_traj_controller:
+    type: "position_controllers/JointTrajectoryController"
+    joints:
+      - r_leg_hip_y
+      - r_leg_hip_r
+      - r_leg_hip_p
+      - r_leg_kn_p
+      - r_leg_an_r
+      - r_leg_an_p
+      
+    constraints:
+      goal_time: *goal_time_constraint
+      stopped_velocity_tolerance: 1.0
+      r_leg_hip_y:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      r_leg_hip_r:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint        
+      r_leg_hip_p:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      r_leg_kn_p:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint        
+      r_leg_an_r:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint
+      r_leg_an_p:
+        goal: *goal_pos_constraint
+        trajectory: *trajectory_pos_constraint

--- a/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
+++ b/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
@@ -70,21 +70,27 @@ public:
   bool isRunning() override;
 
 private:
+  void controllerManagerThread();
   void queueThread();
 
   int control_cycle_msec_;
+  boost::thread controller_manager_thread_;
   boost::thread queue_thread_;
   ros::Time last_time_stamp_;
+
+  bool reset_controllers_;
+
+  boost::mutex ros_control_mutex_;
   
   /** ROS CONTROL PART */
   boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
 
   // IMU
   hardware_interface::ImuSensorInterface imu_sensor_interface_;
-  hardware_interface::ImuSensorHandle::Data imu_data;
-  double imu_orientation[4];
-  double imu_angular_velocity[3];
-  double imu_linear_acceleration[3];
+  hardware_interface::ImuSensorHandle::Data imu_data_;
+  double imu_orientation_[4];
+  double imu_angular_velocity_[3];
+  double imu_linear_acceleration_[3];
 
   // FT-Sensors
   hardware_interface::ForceTorqueSensorInterface force_torque_sensor_interface_;

--- a/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
+++ b/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
@@ -36,7 +36,7 @@
 #include <std_msgs/Int16.h>
 
 // robotis
-#include <robotis_framework_common/MotionModule.h>
+#include <robotis_framework_common/motion_module.h>
 
 // ros control
 #include <controller_manager/controller_manager.h>
@@ -46,23 +46,26 @@
 
 
 
-namespace ROBOTIS
+namespace thormang3
 {
 class RosControlModule
-  : public Singleton<RosControlModule>
-  , public MotionModule
+  : public robotis_framework::Singleton<RosControlModule>
+  , public robotis_framework::MotionModule
   , public hardware_interface::RobotHW
 {
 public:
   RosControlModule();
   virtual ~RosControlModule();
 
-  void Initialize(const int control_cycle_msec, Robot* robot) override;
+  void onModuleEnable() override {}
+  void onModuleDisable() override {}
 
-  void Process(std::map<std::string, Dynamixel*> dxls, std::map<std::string, double> sensors) override;
+  void initialize(const int control_cycle_msec, robotis_framework::Robot* robot) override;
 
-  void Stop() override;
-  bool IsRunning() override;
+  void process(std::map<std::string, robotis_framework::Dynamixel*> dxls, std::map<std::string, double> sensors) override;
+
+  void stop() override;
+  bool isRunning() override;
 
 private:
   void QueueThread();

--- a/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
+++ b/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
@@ -70,7 +70,7 @@ public:
   bool isRunning() override;
 
 private:
-  void msgQueueThread();
+  void queueThread();
 
   int control_cycle_msec_;
   boost::thread queue_thread_;

--- a/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
+++ b/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
@@ -68,7 +68,7 @@ public:
   bool isRunning() override;
 
 private:
-  void QueueThread();
+  void msgQueueThread();
 
   int control_cycle_msec_;
   boost::thread queue_thread_;

--- a/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
+++ b/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
@@ -41,6 +41,8 @@
 // ros control
 #include <controller_manager/controller_manager.h>
 #include <hardware_interface/robot_hw.h>
+#include <hardware_interface/imu_sensor_interface.h>
+#include <hardware_interface/force_torque_sensor_interface.h>
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/joint_state_interface.h>
 
@@ -74,10 +76,22 @@ private:
   boost::thread queue_thread_;
   ros::Time last_time_stamp_;
   
-  // ros control
-  
+  /** ROS CONTROL PART */
   boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
+
+  // IMU
+  hardware_interface::ImuSensorInterface imu_sensor_interface_;
+  hardware_interface::ImuSensorHandle::Data imu_data;
+  double imu_orientation[4];
+  double imu_angular_velocity[3];
+  double imu_linear_acceleration[3];
+
+  // FT-Sensors
+  hardware_interface::ForceTorqueSensorInterface force_torque_sensor_interface_;
+  std::map<std::string, double[3]> force_;
+  std::map<std::string, double[3]> torque_;
   
+  // joint interfaces
   hardware_interface::JointStateInterface jnt_state_interface_;
   hardware_interface::PositionJointInterface jnt_pos_interface_;
   std::map<std::string, double> cmd_;

--- a/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
+++ b/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
@@ -1,0 +1,88 @@
+//=================================================================================================
+// Copyright (c) 2016, Alexander Stumpf, TU Darmstadt
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the Simulation, Systems Optimization and Robotics
+//       group, TU Darmstadt nor the names of its contributors may be used to
+//       endorse or promote products derived from this software without
+//       specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//=================================================================================================
+
+#ifndef ROS_CONTROL_MODULE_H_
+#define ROS_CONTROL_MODULE_H_
+
+#include <ros/ros.h>
+
+#include <boost/thread.hpp>
+#include <ros/callback_queue.h>
+#include <std_msgs/Int16.h>
+
+// robotis
+#include <robotis_framework_common/MotionModule.h>
+
+// ros control
+#include <controller_manager/controller_manager.h>
+#include <hardware_interface/robot_hw.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/joint_state_interface.h>
+
+
+
+namespace ROBOTIS
+{
+class RosControlModule
+  : public Singleton<RosControlModule>
+  , public MotionModule
+  , public hardware_interface::RobotHW
+{
+public:
+  RosControlModule();
+  virtual ~RosControlModule();
+
+  void Initialize(const int control_cycle_msec, Robot* robot) override;
+
+  void Process(std::map<std::string, Dynamixel*> dxls, std::map<std::string, double> sensors) override;
+
+  void Stop() override;
+  bool IsRunning() override;
+
+private:
+  void QueueThread();
+
+  int control_cycle_msec_;
+  boost::thread queue_thread_;
+  ros::Time last_time_stamp_;
+  
+  // ros control
+  
+  boost::shared_ptr<controller_manager::ControllerManager> controller_manager;
+  
+  hardware_interface::JointStateInterface jnt_state_interface_;
+  hardware_interface::PositionJointInterface jnt_pos_interface_;
+  std::map<std::string, double> cmd_;
+  std::map<std::string, double> pos_;
+  std::map<std::string, double> vel_;
+  std::map<std::string, double> eff_;
+};
+}
+
+#endif
+

--- a/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
+++ b/thormang3_ros_control_module/include/thormang3_ros_control_module/ros_control_module.h
@@ -76,7 +76,7 @@ private:
   
   // ros control
   
-  boost::shared_ptr<controller_manager::ControllerManager> controller_manager;
+  boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
   
   hardware_interface::JointStateInterface jnt_state_interface_;
   hardware_interface::PositionJointInterface jnt_pos_interface_;

--- a/thormang3_ros_control_module/launch/load_position_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_position_controllers.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<launch>  
+  <arg name="namespace" default="/thor_mang"/>
+  <group ns="$(arg namespace)">
+    <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" />
+    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_position_controllers.yaml" command="load" />
+
+    <!-- load position controllers -->
+    <node name="position_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+      args="--stopped
+            head_p_position_controller
+            head_y_position_controller"/>
+  </group>
+</launch>
+

--- a/thormang3_ros_control_module/launch/load_position_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_position_controllers.launch
@@ -1,15 +1,12 @@
 <?xml version="1.0"?>
 
 <launch>
-  <group ns="joints">
-    <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" ns="ros_control_module" />
-    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_position_controllers.yaml" command="load" />
+  <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" ns="ros_control_module" />
+  <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_position_controllers.yaml" command="load" />
 
-    <!-- load position controllers -->
-    <node name="position_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
-      args="--stopped
-            head_p_position_controller
-            head_y_position_controller"/>
-  </group>
+  <!-- load position controllers -->
+  <node name="position_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+    args="head_p_position_controller
+          head_y_position_controller"/>
 </launch>
 

--- a/thormang3_ros_control_module/launch/load_position_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_position_controllers.launch
@@ -1,13 +1,15 @@
 <?xml version="1.0"?>
 
 <launch>
-  <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" />
-  <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_position_controllers.yaml" command="load" />
+  <group ns="joints">
+    <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" ns="ros_control_module" />
+    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_position_controllers.yaml" command="load" />
 
-  <!-- load position controllers -->
-  <node name="position_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
-    args="--stopped
-          head_p_position_controller
-          head_y_position_controller"/>
+    <!-- load position controllers -->
+    <node name="position_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+      args="--stopped
+            head_p_position_controller
+            head_y_position_controller"/>
+  </group>
 </launch>
 

--- a/thormang3_ros_control_module/launch/load_position_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_position_controllers.launch
@@ -1,16 +1,13 @@
 <?xml version="1.0"?>
 
-<launch>  
-  <arg name="namespace" default="/thor_mang"/>
-  <group ns="$(arg namespace)">
-    <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" />
-    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_position_controllers.yaml" command="load" />
+<launch>
+  <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" />
+  <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_position_controllers.yaml" command="load" />
 
-    <!-- load position controllers -->
-    <node name="position_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
-      args="--stopped
-            head_p_position_controller
-            head_y_position_controller"/>
-  </group>
+  <!-- load position controllers -->
+  <node name="position_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+    args="--stopped
+          head_p_position_controller
+          head_y_position_controller"/>
 </launch>
 

--- a/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
@@ -2,8 +2,8 @@
 
 <launch>
   <group ns="joints">
-    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
     <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" ns="ros_control_module" />
+    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
 
     <!-- load trajectory controllers -->
     <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"

--- a/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<launch>
+  <arg name="namespace" default="/thor_mang"/>
+  <group ns="$(arg namespace)">
+    <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" />
+    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
+
+    <!-- load trajectory controllers -->
+    <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+      args="--stopped
+            head_traj_controller
+            torso_traj_controller
+            left_arm_traj_controller
+            right_arm_traj_controller"/>
+  </group>
+</launch>
+

--- a/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
@@ -1,15 +1,17 @@
 <?xml version="1.0"?>
 
 <launch>
-  <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" />
-  <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
+  <group ns="joints">
+    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
+    <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" ns="ros_control_module" />
 
-  <!-- load trajectory controllers -->
-  <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
-    args="--stopped
-          head_traj_controller
-          torso_traj_controller
-          left_arm_traj_controller
-          right_arm_traj_controller"/>
+    <!-- load trajectory controllers -->
+    <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+      args="--stopped
+            head_traj_controller
+            torso_traj_controller
+            left_arm_traj_controller
+            right_arm_traj_controller"/>
+  </group>
 </launch>
 

--- a/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
@@ -1,17 +1,16 @@
 <?xml version="1.0"?>
 
 <launch>
-  <group ns="joints">
-    <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" ns="ros_control_module" />
-    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
+  <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" ns="ros_control_module" />
+  <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
 
-    <!-- load trajectory controllers -->
-    <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
-      args="--stopped
-            head_traj_controller
-            torso_traj_controller
-            left_arm_traj_controller
-            right_arm_traj_controller"/>
-  </group>
+  <!-- load trajectory controllers -->
+  <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+    args="head_traj_controller
+          torso_traj_controller
+          left_arm_traj_controller
+          right_arm_traj_controller
+          left_leg_traj_controller
+          right_leg_traj_controller"/>
 </launch>
 

--- a/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
+++ b/thormang3_ros_control_module/launch/load_trajectory_controllers.launch
@@ -1,18 +1,15 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="namespace" default="/thor_mang"/>
-  <group ns="$(arg namespace)">
-    <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" />
-    <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
+  <rosparam file="$(find thormang3_ros_control_module)/config/ros_control_module_config.yaml" command="load" />
+  <rosparam file="$(find thormang3_ros_control_module)/config/thor_mang_trajectory_controllers.yaml" command="load" />
 
-    <!-- load trajectory controllers -->
-    <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
-      args="--stopped
-            head_traj_controller
-            torso_traj_controller
-            left_arm_traj_controller
-            right_arm_traj_controller"/>
-  </group>
+  <!-- load trajectory controllers -->
+  <node name="trajectory_controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen"
+    args="--stopped
+          head_traj_controller
+          torso_traj_controller
+          left_arm_traj_controller
+          right_arm_traj_controller"/>
 </launch>
 

--- a/thormang3_ros_control_module/package.xml
+++ b/thormang3_ros_control_module/package.xml
@@ -50,7 +50,7 @@
   <build_depend>hardware_interface</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>controller_manager</build_depend>
-  <build_depend>robotis_device</build_depend>
+  <build_depend>robotis_framework_common</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
@@ -60,7 +60,7 @@
   <run_depend>hardware_interface</run_depend>
   <run_depend>controller_interface</run_depend>
   <run_depend>controller_manager</run_depend>
-  <run_depend>robotis_device</run_depend>
+  <run_depend>robotis_framework_common</run_depend>
 
   <export>
   </export>

--- a/thormang3_ros_control_module/package.xml
+++ b/thormang3_ros_control_module/package.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<package>
+  <name>thormang3_ros_control_module</name>
+  <version>0.0.0</version>
+  <description>The thormang3_ros_control_module package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="stumpf@sim.tu-darmstadt.de">Alexander Stumpf</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>BSD</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/thormang3_ros_control_module</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+  <author email="stumpf@sim.tu-darmstadt.de">Alexander Stumpf</author>
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>controller_interface</build_depend>
+  <build_depend>controller_manager</build_depend>
+  <build_depend>robotis_device</build_depend>
+
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>actionlib</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>hardware_interface</run_depend>
+  <run_depend>controller_interface</run_depend>
+  <run_depend>controller_manager</run_depend>
+  <run_depend>robotis_device</run_depend>
+
+  <export>
+  </export>
+</package>

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -156,7 +156,7 @@ void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixe
       eff_[joint_name] = dynamixel->dxl_state_->present_torque_;
     }
     else
-      ROS_ERROR_ONCE("[RosControlModule] Joint '%s' is not available!", joint_name.c_str());
+      ROS_WARN_ONCE("[RosControlModule] Joint '%s' is not available!", joint_name.c_str());
   }
 
   /** call controllers */

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -41,7 +41,7 @@ void RosControlModule::initialize(const int control_cycle_msec, robotis_framewor
   
   last_time_stamp_ = ros::Time::now();
   
-  queue_thread_ = boost::thread(boost::bind(&RosControlModule::QueueThread, this));
+  queue_thread_ = boost::thread(boost::bind(&RosControlModule::msgQueueThread, this));
   
   jnt_state_interface_ = hardware_interface::JointStateInterface();
   jnt_pos_interface_ = hardware_interface::PositionJointInterface();
@@ -102,7 +102,7 @@ void RosControlModule::stop()
   return;
 }
 
-void RosControlModule::QueueThread()
+void RosControlModule::msgQueueThread()
 {
   ros::NodeHandle _ros_node("/thor_mang"); // TODO: Namespace handling
   ros::CallbackQueue _callback_queue;
@@ -110,7 +110,7 @@ void RosControlModule::QueueThread()
   _ros_node.setCallbackQueue(&_callback_queue);
   
   // Initialize ros control
-  controller_manager_.reset(new controller_manager_::ControllerManager(this, _ros_node));
+  controller_manager_.reset(new controller_manager::ControllerManager(this, _ros_node));
 
   while(_ros_node.ok())
   {

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -148,9 +148,15 @@ void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixe
   {
     const std::string& joint_name = state_iter->first;
     
-    pos_[joint_name] = dxls[state_iter->first]->dxl_state_->present_position_;
-    vel_[joint_name] = dxls[state_iter->first]->dxl_state_->present_velocity_;
-    eff_[joint_name] = dxls[state_iter->first]->dxl_state_->present_torque_;
+    const robotis_framework::Dynamixel* dynamixel = dxls[joint_name];
+    if (dynamixel)
+    {
+      pos_[joint_name] = dynamixel->dxl_state_->present_position_;
+      vel_[joint_name] = dynamixel->dxl_state_->present_velocity_;
+      eff_[joint_name] = dynamixel->dxl_state_->present_torque_;
+    }
+    else
+      ROS_ERROR_ONCE("[RosControlModule] Joint '%s' is not available!", joint_name.c_str());
   }
 
   /** call controllers */

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -19,6 +19,7 @@ RosControlModule::~RosControlModule()
   for (auto& kv : result_)
     delete kv.second;
 
+  controller_manager_thread_.join();
   queue_thread_.join();
 }
 
@@ -85,6 +86,7 @@ void RosControlModule::initialize(const int control_cycle_msec, robotis_framewor
   /** initialize joints */
 
   // read joints from ros param server
+  /// TODO: Check available joints with 'robot' parameter
   result_.clear();
   XmlRpc::XmlRpcValue joints = nh.param("joints", XmlRpc::XmlRpcValue());
   if (joints.getType() == XmlRpc::XmlRpcValue::TypeArray)
@@ -148,12 +150,12 @@ void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixe
   {
     const std::string& joint_name = state_iter->first;
     
-    const robotis_framework::Dynamixel* dynamixel = dxls[joint_name];
-    if (dynamixel)
+    const robotis_framework::Dynamixel* dxl = dxls[joint_name];
+    if (dxl)
     {
-      pos_[joint_name] = dynamixel->dxl_state_->present_position_;
-      vel_[joint_name] = dynamixel->dxl_state_->present_velocity_;
-      eff_[joint_name] = dynamixel->dxl_state_->present_torque_;
+      pos_[joint_name] = dxl->dxl_state_->present_position_;
+      vel_[joint_name] = dxl->dxl_state_->present_velocity_;
+      eff_[joint_name] = dxl->dxl_state_->present_torque_;
     }
     else
       ROS_WARN_ONCE("[RosControlModule] Joint '%s' is not available!", joint_name.c_str());

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -29,7 +29,7 @@ void RosControlModule::initialize(const int control_cycle_msec, robotis_framewor
 
   control_cycle_msec_ = control_cycle_msec;
 
-  ros::NodeHandle nh("joints/ros_control_module");
+  ros::NodeHandle nh("ros_control_module");
 
   // clear already exisiting outputs
   for (auto& kv : result_)
@@ -224,7 +224,7 @@ void RosControlModule::queueThread()
 {
   ros_control_mutex_.lock();
 
-  ros::NodeHandle nh("joints");
+  ros::NodeHandle nh;
   ros::CallbackQueue callback_queue;
 
   nh.setCallbackQueue(&callback_queue);

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -193,11 +193,11 @@ void RosControlModule::controllerManagerThread()
   {
     usleep(control_cycle_msec_);
 
+    boost::mutex::scoped_lock lock(ros_control_mutex_);
+
     // skip if enabled as Process will update controller
     if (enable_)
       continue;
-
-    boost::mutex::scoped_lock lock(ros_control_mutex_);
 
     // time measurements
     ros::Time current_time = ros::Time::now();

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -191,10 +191,8 @@ void RosControlModule::queueThread()
   // Initialize ros control
   controller_manager_.reset(new controller_manager::ControllerManager(this, nh));
 
+  ros::WallDuration duration(control_cycle_msec_/1000.0);
   while(nh.ok())
-  {
-    callback_queue.callAvailable();
-    usleep(100);
-  }
+    callback_queue.callAvailable(duration);
 }
 }

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -69,7 +69,7 @@ void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixe
   
   if (!enable_)
   {
-    controller_manager->update(ros::Time::now(), elapsed_time);
+    controller_manager_->update(ros::Time::now(), elapsed_time);
     return;
   }
 
@@ -82,7 +82,7 @@ void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixe
     eff_[joint_name] = dxls[state_iter->first]->dxl_state_->present_torque_;
   }
 
-  controller_manager->update(ros::Time::now(), elapsed_time);
+  controller_manager_->update(ros::Time::now(), elapsed_time);
   
   for(std::map<std::string, robotis_framework::DynamixelState*>::iterator state_iter = result_.begin(); state_iter != result_.end(); state_iter++)
   {
@@ -110,7 +110,7 @@ void RosControlModule::QueueThread()
   _ros_node.setCallbackQueue(&_callback_queue);
   
   // Initialize ros control
-  controller_manager.reset(new controller_manager::ControllerManager(this, _ros_node));
+  controller_manager_.reset(new controller_manager_::ControllerManager(this, _ros_node));
 
   while(_ros_node.ok())
   {

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -5,7 +5,7 @@
 namespace thormang3
 {
 RosControlModule::RosControlModule()
-    : control_cycle_msec_(8)
+  : control_cycle_msec_(8)
 {
   enable_          = false;
   module_name_     = "ros_control_module"; // set unique module name
@@ -32,7 +32,7 @@ void RosControlModule::initialize(const int control_cycle_msec, robotis_framewor
   
   last_time_stamp_ = ros::Time::now();
   
-  queue_thread_ = boost::thread(boost::bind(&RosControlModule::msgQueueThread, this));
+  queue_thread_ = boost::thread(boost::bind(&RosControlModule::queueThread, this));
 
   ros::NodeHandle nh;
 
@@ -87,6 +87,7 @@ void RosControlModule::initialize(const int control_cycle_msec, robotis_framewor
   /** initialize joints */
 
   // read joints from ros param server
+  result_.clear();
   XmlRpc::XmlRpcValue joints = nh.param("joints", XmlRpc::XmlRpcValue());
   if (joints.getType() == XmlRpc::XmlRpcValue::TypeArray)
   {
@@ -180,7 +181,7 @@ void RosControlModule::stop()
   return;
 }
 
-void RosControlModule::msgQueueThread()
+void RosControlModule::queueThread()
 {
   ros::NodeHandle nh;
   ros::CallbackQueue callback_queue;

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -11,27 +11,18 @@ RosControlModule::RosControlModule()
   module_name_     = "ros_control_module"; // set unique module name
   control_mode_    = robotis_framework::PositionControl;
   
-  ros::NodeHandle nh("/thor_mang"); // TODO: Namespace handling
-  
-  XmlRpc::XmlRpcValue joints = nh.param("joints", XmlRpc::XmlRpcValue());
-  
-  if (joints.getType() == XmlRpc::XmlRpcValue::TypeArray)
-  {
-    for (size_t i = 0; i < joints.size(); i++)
-    {
-      result_[static_cast<std::string>(joints[i])] = new robotis_framework::DynamixelState();
-      ROS_WARN("Joint: %s", static_cast<std::string>(joints[i]).c_str());
-    }
-  }
-  else
-    ROS_ERROR("[RosControlModule] Joints must be given as an array of strings.");
-  
+  // (pre-)register interfaces
+  registerInterface(&imu_sensor_interface_);
+  registerInterface(&force_torque_sensor_interface_);
   registerInterface(&jnt_state_interface_);
   registerInterface(&jnt_pos_interface_);
 }
 
 RosControlModule::~RosControlModule()
 {
+  for (auto& kv : result_)
+    delete kv.second;
+
   queue_thread_.join();
 }
 
@@ -42,11 +33,73 @@ void RosControlModule::initialize(const int control_cycle_msec, robotis_framewor
   last_time_stamp_ = ros::Time::now();
   
   queue_thread_ = boost::thread(boost::bind(&RosControlModule::msgQueueThread, this));
+
+  ros::NodeHandle nh;
+
+  // clear already exisiting outputs
+  for (auto& kv : result_)
+    delete kv.second;
+  result_.clear();
+
+  /** initialize IMU */
+
+  imu_sensor_interface_ = hardware_interface::ImuSensorInterface();
+
+  imu_data.name = "waist_imu";
+  imu_data.frame_id = "imu_link";
+  imu_data.orientation = imu_orientation;
+  imu_data.angular_velocity = imu_angular_velocity;
+  imu_data.linear_acceleration = imu_linear_acceleration;
+  hardware_interface::ImuSensorHandle imu_sensor_handle(imu_data);
+  imu_sensor_interface_.registerHandle(imu_sensor_handle);
+
+  /** initialize FT-Sensors */
+
+  force_torque_sensor_interface_ = hardware_interface::ForceTorqueSensorInterface();
+
+  // read ft sensors from ros param server
+  XmlRpc::XmlRpcValue ft_sensors = nh.param("ft_sensors", XmlRpc::XmlRpcValue());
+  if (ft_sensors.getType() == XmlRpc::XmlRpcValue::TypeStruct)
+  {
+    for (XmlRpc::XmlRpcValue::iterator itr = ft_sensors.begin(); itr != ft_sensors.end(); itr++)
+    {
+      const std::string& sensor = itr->first;
+      XmlRpc::XmlRpcValue val = itr->second;
+
+      if (val.getType() == XmlRpc::XmlRpcValue::TypeArray && val.size() >= 2)
+      {
+        for (size_t i = 0; i < val.size(); i++)
+        {
+          const std::string& name = val[0];
+          const std::string& frame_id = val[1];
+
+          hardware_interface::ForceTorqueSensorHandle ft_sensor_handle(name, frame_id, force_[sensor], torque_[sensor]);
+          force_torque_sensor_interface_.registerHandle(ft_sensor_handle);
+        }
+      }
+      else
+        ROS_ERROR("[RosControlModule] FT-Sensors info must be given as array of strings.");
+    }
+  }
+  else
+    ROS_ERROR("[RosControlModule] FT-Sensors config malformed.");
+
+  /** initialize joints */
+
+  // read joints from ros param server
+  XmlRpc::XmlRpcValue joints = nh.param("joints", XmlRpc::XmlRpcValue());
+  if (joints.getType() == XmlRpc::XmlRpcValue::TypeArray)
+  {
+    for (size_t i = 0; i < joints.size(); i++)
+      result_[static_cast<std::string>(joints[i])] = new robotis_framework::DynamixelState();
+  }
+  else
+    ROS_ERROR("[RosControlModule] Joints must be given as an array of strings.");
   
   jnt_state_interface_ = hardware_interface::JointStateInterface();
   jnt_pos_interface_ = hardware_interface::PositionJointInterface();
   
-  for(std::map<std::string, robotis_framework::DynamixelState*>::iterator state_iter = result_.begin(); state_iter != result_.end(); state_iter++)
+  for (std::map<std::string, robotis_framework::DynamixelState*>::iterator state_iter = result_.begin(); state_iter != result_.end(); state_iter++)
   {
     const std::string& joint_name = state_iter->first;
     
@@ -60,7 +113,7 @@ void RosControlModule::initialize(const int control_cycle_msec, robotis_framewor
   }
 }
 
-void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixel*> dxls, std::map<std::string, double> /*sensors*/)
+void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixel*> dxls, std::map<std::string, double> sensors)
 {
   // time measurements
   ros::Time current_time = ros::Time::now();
@@ -73,6 +126,27 @@ void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixe
     return;
   }
 
+  /** update IMU */
+
+  // TODO
+
+  /** update FT-Sensors */
+
+  for (auto& kv : force_)
+  {
+    kv.second[0] = sensors[kv.first + "_fx_raw_N"];
+    kv.second[1] = sensors[kv.first + "_fy_raw_N"];
+    kv.second[2] = sensors[kv.first + "_fz_raw_N"];
+  }
+  for (auto& kv : torque_)
+  {
+    kv.second[0] = sensors[kv.first + "_tx_raw_Nm"];
+    kv.second[1] = sensors[kv.first + "_ty_raw_Nm"];
+    kv.second[2] = sensors[kv.first + "_tz_raw_Nm"];
+  }
+
+  /** update joints */
+
   for(std::map<std::string, robotis_framework::DynamixelState*>::iterator state_iter = result_.begin(); state_iter != result_.end(); state_iter++)
   {
     const std::string& joint_name = state_iter->first;
@@ -82,7 +156,11 @@ void RosControlModule::process(std::map<std::string, robotis_framework::Dynamixe
     eff_[joint_name] = dxls[state_iter->first]->dxl_state_->present_torque_;
   }
 
+  /** call controllers */
+
   controller_manager_->update(ros::Time::now(), elapsed_time);
+
+  /** write back commands */
   
   for(std::map<std::string, robotis_framework::DynamixelState*>::iterator state_iter = result_.begin(); state_iter != result_.end(); state_iter++)
   {
@@ -104,17 +182,17 @@ void RosControlModule::stop()
 
 void RosControlModule::msgQueueThread()
 {
-  ros::NodeHandle _ros_node("/thor_mang"); // TODO: Namespace handling
-  ros::CallbackQueue _callback_queue;
+  ros::NodeHandle nh;
+  ros::CallbackQueue callback_queue;
 
-  _ros_node.setCallbackQueue(&_callback_queue);
+  nh.setCallbackQueue(&callback_queue);
   
   // Initialize ros control
-  controller_manager_.reset(new controller_manager::ControllerManager(this, _ros_node));
+  controller_manager_.reset(new controller_manager::ControllerManager(this, nh));
 
-  while(_ros_node.ok())
+  while(nh.ok())
   {
-    _callback_queue.callAvailable();
+    callback_queue.callAvailable();
     usleep(100);
   }
 }

--- a/thormang3_ros_control_module/src/ros_control_module.cpp
+++ b/thormang3_ros_control_module/src/ros_control_module.cpp
@@ -1,0 +1,121 @@
+#include <thormang3_ros_control_module/ros_control_module.h>
+
+
+
+namespace ROBOTIS
+{
+RosControlModule::RosControlModule()
+    : control_cycle_msec_(8)
+{
+  enable          = false;
+  module_name     = "ros_control_module"; // set unique module name
+  control_mode    = POSITION_CONTROL;
+  
+  ros::NodeHandle nh("/thor_mang"); // TODO: Namespace handling
+  
+  XmlRpc::XmlRpcValue joints = nh.param("joints", XmlRpc::XmlRpcValue());
+  
+  if (joints.getType() == XmlRpc::XmlRpcValue::TypeArray)
+  {
+    for (size_t i = 0; i < joints.size(); i++)
+    {
+      result[static_cast<std::string>(joints[i])] = new DynamixelState();
+      ROS_WARN("Joint: %s", static_cast<std::string>(joints[i]).c_str());
+    }
+  }
+  else
+    ROS_ERROR("[RosControlModule] Joints must be given as an array of strings.");
+  
+  registerInterface(&jnt_state_interface_);
+  registerInterface(&jnt_pos_interface_);
+}
+
+RosControlModule::~RosControlModule()
+{
+  queue_thread_.join();
+}
+
+void RosControlModule::Initialize(const int control_cycle_msec, Robot* robot)
+{
+  control_cycle_msec_ = control_cycle_msec;
+  
+  last_time_stamp_ = ros::Time::now();
+  
+  queue_thread_ = boost::thread(boost::bind(&RosControlModule::QueueThread, this));
+  
+  jnt_state_interface_ = hardware_interface::JointStateInterface();
+  jnt_pos_interface_ = hardware_interface::PositionJointInterface();
+  
+  for(std::map<std::string, DynamixelState*>::iterator state_iter = result.begin(); state_iter != result.end(); state_iter++)
+  {
+    const std::string& joint_name = state_iter->first;
+    
+    // connect and register the joint state interface
+    hardware_interface::JointStateHandle state_handle(joint_name, &pos_[joint_name], &vel_[joint_name], &eff_[joint_name]);
+    jnt_state_interface_.registerHandle(state_handle);
+    
+    // connect and register the joint position interface
+    hardware_interface::JointHandle pos_handle(state_handle, &cmd_[joint_name]);
+    jnt_pos_interface_.registerHandle(pos_handle);
+  }
+}
+
+void RosControlModule::Process(std::map<std::string, Dynamixel*> dxls, std::map<std::string, double> /*sensors*/)
+{
+  // time measurements
+  ros::Time current_time = ros::Time::now();
+  ros::Duration elapsed_time = current_time - last_time_stamp_;
+  last_time_stamp_ = current_time;
+  
+  if (!enable)
+  {
+    controller_manager->update(ros::Time::now(), elapsed_time);
+    return;
+  }
+
+  for(std::map<std::string, DynamixelState*>::iterator state_iter = result.begin(); state_iter != result.end(); state_iter++)
+  {
+    const std::string& joint_name = state_iter->first;
+    
+    pos_[joint_name] = dxls[state_iter->first]->dxl_state->present_position;
+    vel_[joint_name] = dxls[state_iter->first]->dxl_state->present_velocity;
+    eff_[joint_name] = dxls[state_iter->first]->dxl_state->present_current;
+  }
+
+  controller_manager->update(ros::Time::now(), elapsed_time);
+  
+  for(std::map<std::string, DynamixelState*>::iterator state_iter = result.begin(); state_iter != result.end(); state_iter++)
+  {
+    const std::string& joint_name = state_iter->first;
+    
+    result[joint_name]->goal_position = cmd_[joint_name];
+  }
+}
+
+bool RosControlModule::IsRunning()
+{
+  return false;
+}
+
+void RosControlModule::Stop()
+{
+  return;
+}
+
+void RosControlModule::QueueThread()
+{
+  ros::NodeHandle _ros_node("/thor_mang"); // TODO: Namespace handling
+  ros::CallbackQueue _callback_queue;
+
+  _ros_node.setCallbackQueue(&_callback_queue);
+  
+  // Initialize ros control
+  controller_manager.reset(new controller_manager::ControllerManager(this, _ros_node));
+
+  while(_ros_node.ok())
+  {
+    _callback_queue.callAvailable();
+    usleep(100);
+  }
+}
+}


### PR DESCRIPTION
We would like to see official support for the famous ROS Control framework http://wiki.ros.org/ros_control. This is the backport of our version that we are successfully using on Johnny#5. ROS Control enables to share advanced controls methods across the community, such as our bilateral tele-operation system:
https://www.youtube.com/watch?v=PxDxUY0QzfM
https://www.youtube.com/watch?v=qot0_3341i0
or compliant control based on wrist FT sensors (to be published).

Features:
- Adds full ROS Control support on joint level
- Sensor interfaces implemented
- Joint Position/Trajectory controller pre-configured

Requirements:
- Installed ROS Control (e.g. sudo apt-get install ros-kinetic-ros-control ros-kinetic-ros-controllers)
- ROBOTIS-GIT/ROBOTIS-Framework#26
- ROBOTIS-GIT/ROBOTIS-THORMANG-MPC#16
- ROBOTIS-GIT/ROBOTIS-THORMANG-OPC#6

Usage:
- Start up robot as used to (real or simulated)
- Switch to ros_control_module mode in Demo UI (requires ROBOTIS-GIT/ROBOTIS-THORMANG-OPC#6)
- Start rqt
- Add trajectory controller plugin (Plugins->Robot Tools->Joint trajectory controller)
- Select any trajectory controller from list (using controller manager namespace '/')
- Enable it and have fun!

Limitations:
- Although lMU and FT sensor interfaces are already implemented, we haven't verified the correctness of sensor data by now. 
